### PR TITLE
change port to 80 for linux example

### DIFF
--- a/docker-intro.md
+++ b/docker-intro.md
@@ -151,7 +151,7 @@ $ curl http://$(boot2docker ip):1337
 Otherwise, if we're using Linux we simply request localhost:
 
 ```bash
-$ curl http://localhost:1337
+$ curl http://localhost:80
 ```
 
 


### PR DESCRIPTION
The port for the exposed node service was incorrect for linux. It should have been 80. 
