### PR TITLE
port 1337 didn't work

### DIFF
--- a/docker-intro.md
+++ b/docker-intro.md
@@ -146,7 +146,7 @@ we need to use the $DOCKER_HOST environment variable to access the VM's
 localhost.
 
 ```bash
-$ curl http://$(boot2docker ip):1337
+$ curl http://$(boot2docker ip):80
 ```
 Otherwise, if we're using Linux we simply request localhost:
 


### PR DESCRIPTION
Running docker run -p 80:1337 <containerid>

Following command didn't work

``` bash
$ curl http://$(boot2docker ip):1337
```

But this worked for me

``` bash
$ curl http://$(boot2docker ip):80
```

Not being an expert I guess it is right to use the hostPort (from the doc : " hostPort:containerPort ")
