### PR TITLE
Update doc to match port in sample app

### DIFF
--- a/ex2.md
+++ b/ex2.md
@@ -209,12 +209,12 @@ Our container should be running just fine, we can use the following to see it in
 
 OS X : 
 ```bash
-$ curl http://$(boot2docker ip):8000
+$ curl http://$(boot2docker ip):1337
 ```
 
 Linux:
 ```bash
-$ curl http://localhost:8000
+$ curl http://localhost:1337
 ```
 
 [Next up: exercise 3](https://github.com/nearform/nscale-workshop/blob/master/ex3.md)


### PR DESCRIPTION
The sample app at https://github.com/nearform/nscale-workshop-intro-docker-sample
exposes port 1337, not 8000
